### PR TITLE
Update devDeps eleventy, eleventy-img, and linkedom

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
 	},
 	"homepage": "https://github.com/11ty/eleventy-tugboat#readme",
 	"devDependencies": {
-		"@11ty/eleventy": "3.0.0-alpha.1",
-		"@11ty/eleventy-img": "^3.1.8",
+		"@11ty/eleventy": "3.0.0-alpha.14",
+		"@11ty/eleventy-img": "^4.0.2",
 		"@11ty/eleventy-plugin-syntaxhighlight": "^5.0.0",
 		"@11ty/eleventy-plugin-webc": "^0.11.2",
 		"emoji-short-name": "^2.0.0",
-		"linkedom": "^0.14.25"
+		"linkedom": "^0.18.4"
 	},
 	"dependencies": {
 		"@11ty/is-land": "^4.0.0"


### PR DESCRIPTION
Update devDeps eleventy 3.0.0-alpha.14, eleventy-img 4.0.2, linkedom 0.18.4

@11ty/eleventy 3.0.0-alpha.1 - 3.0.0-alpha.14

https://github.com/11ty/eleventy/compare/v3.0.0-alpha.1...v3.0.0-alpha.14

@11ty/eleventy-img ^3.1.8 - ^4.0.2

https://github.com/11ty/eleventy-img/compare/v3.1.8...v4.0.2

linkedom ^0.14.25 - ^0.18.4

https://github.com/WebReflection/linkedom/compare/v0.14.25...v0.18.4

Side note, this is a precursor PR to my [beginning to tinker](https://mastodon.social/@rdela/112689989457173792) around here 🛟✨🍩 